### PR TITLE
Add hex code computation as a method (I did this because the version …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,9 @@ capture the resulting hexcodes from the colormap and store them as an attribute.
 
 Output:
 
-['#ba7469', '#dfd67d', '#5d536a', '#321e28']
+::
+
+    ['#ba7469', '#dfd67d', '#5d536a', '#321e28']
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,22 @@ Make two ImageConverter objects:
         n_colors=3, palette_name="no_transparent", random_state=42
     )
 
+Compute hexcodes: 
+
+img2cmap computes the RGB values of an image and stores it in the `self.pixels` array. 
+For cases where the hexcodes are needed, running the `compute_hexcodes` method will compute the hexcodes
+and store them as an attribute (`self.hexcodes`).
+
+.. code-block:: python3
+
+    from img2cmap import ImageConverter
+
+    image_url = "https://static1.bigstockphoto.com/3/2/3/large1500/323952496.jpg"
+
+    converter = ImageConverter(image_url)
+    converter.compute_hexcodes()
+    print(converter.hexcodes[:20])
+
 Plot both colormaps with the image:
 
 

--- a/README.rst
+++ b/README.rst
@@ -110,9 +110,8 @@ Make two ImageConverter objects:
 
 Compute hexcodes: 
 
-img2cmap computes the RGB values of an image and stores it in the ``self.pixels`` array. 
-For cases where the hexcodes are needed, running the ``compute_hexcodes`` method will compute the hexcodes
-and store them as an attribute (``self.hexcodes``).
+When running the ``generate_cmap`` or the ``generate_optimal_cmap`` methods the ImageConverter object will automatically 
+capture the resulting hexcodes from the colormap and store them as an attribute.
 
 .. code-block:: python3
 
@@ -121,8 +120,8 @@ and store them as an attribute (``self.hexcodes``).
     image_url = "https://static1.bigstockphoto.com/3/2/3/large1500/323952496.jpg"
 
     converter = ImageConverter(image_url)
-    converter.compute_hexcodes()
-    print(converter.hexcodes[:20])
+    converter.generate_cmap(n_colors=4, palette_name="with_transparent", random_state=42)
+    print(converter.hexcodes)
 
 Plot both colormaps with the image:
 

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,8 @@ capture the resulting hexcodes from the colormap and store them as an attribute.
     print(converter.hexcodes)
 
 
-Output: 
+Output:
+
 ['#ba7469', '#dfd67d', '#5d536a', '#321e28']
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,10 @@ capture the resulting hexcodes from the colormap and store them as an attribute.
     converter.generate_cmap(n_colors=4, palette_name="with_transparent", random_state=42)
     print(converter.hexcodes)
 
+
+Output: 
+    ['#ba7469', '#dfd67d', '#5d536a', '#321e28']
+
 Installation
 ============
 

--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ capture the resulting hexcodes from the colormap and store them as an attribute.
 
 
 Output: 
-    ['#ba7469', '#dfd67d', '#5d536a', '#321e28']
+['#ba7469', '#dfd67d', '#5d536a', '#321e28']
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -108,23 +108,8 @@ Make two ImageConverter objects:
         n_colors=3, palette_name="no_transparent", random_state=42
     )
 
-Compute hexcodes: 
-
-When running the ``generate_cmap`` or the ``generate_optimal_cmap`` methods the ImageConverter object will automatically 
-capture the resulting hexcodes from the colormap and store them as an attribute.
-
-.. code-block:: python3
-
-    from img2cmap import ImageConverter
-
-    image_url = "https://static1.bigstockphoto.com/3/2/3/large1500/323952496.jpg"
-
-    converter = ImageConverter(image_url)
-    converter.generate_cmap(n_colors=4, palette_name="with_transparent", random_state=42)
-    print(converter.hexcodes)
 
 Plot both colormaps with the image:
-
 
 .. code-block:: python3
 
@@ -168,6 +153,22 @@ of the image.
         # preserves aspect ratio
         assert imageconverter.image.size == (512, 361)
 
+
+hexcodes
+^^^^^^^^
+
+When running the ``generate_cmap`` or the ``generate_optimal_cmap`` methods the ImageConverter object will automatically 
+capture the resulting hexcodes from the colormap and store them as an attribute.
+
+.. code-block:: python3
+
+    from img2cmap import ImageConverter
+
+    image_url = "https://static1.bigstockphoto.com/3/2/3/large1500/323952496.jpg"
+
+    converter = ImageConverter(image_url)
+    converter.generate_cmap(n_colors=4, palette_name="with_transparent", random_state=42)
+    print(converter.hexcodes)
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -110,9 +110,9 @@ Make two ImageConverter objects:
 
 Compute hexcodes: 
 
-img2cmap computes the RGB values of an image and stores it in the `self.pixels` array. 
-For cases where the hexcodes are needed, running the `compute_hexcodes` method will compute the hexcodes
-and store them as an attribute (`self.hexcodes`).
+img2cmap computes the RGB values of an image and stores it in the ``self.pixels`` array. 
+For cases where the hexcodes are needed, running the ``compute_hexcodes`` method will compute the hexcodes
+and store them as an attribute (``self.hexcodes``).
 
 .. code-block:: python3
 

--- a/src/img2cmap/convert.py
+++ b/src/img2cmap/convert.py
@@ -120,7 +120,7 @@ class ImageConverter:
             self.hexcodes = [mpl.colors.rgb2hex(c) for c in cmaps[best_n_colors].colors]
         except KeyError:
             # Kneed did not find an optimal point so we don't record any hex values
-            pass
+            self.hexcodes = None
         return cmaps, best_n_colors, ssd
 
     def resize(self, size=(512, 512)):

--- a/src/img2cmap/convert.py
+++ b/src/img2cmap/convert.py
@@ -135,9 +135,21 @@ class ImageConverter:
         self.image.thumbnail(size, resampling_technique)
 
     def remove_transparent(self):
-        """Removes the transparent pixels from an image array
+        """Removes the transparent pixels from an image array.
 
         Returns:
             None
         """
         self.pixels = self.pixels[~self.transparent_pixels]
+
+    def compute_hexcodes(self):
+        """Computes the hexcode values from the rgb values of an image array and stores them as an attribute.
+
+        Returns:
+            None
+        """
+
+        def rgb_to_hex(r, g, b):
+            return ("#{:X}{:X}{:X}").format(r, g, b)
+
+        self.hexcodes = [rgb_to_hex(r, g, b) for r, g, b in self.pixels]

--- a/tests/test_img2cmap.py
+++ b/tests/test_img2cmap.py
@@ -137,5 +137,9 @@ def test_compute_optimal_hexcodes():
 def test_break_kneed():
     imageconverter = ImageConverter(image_urls[0])
     # Case where kneed will not return an optimal value
-    imageconverter.generate_optimal_cmap(max_colors=5, random_state=42)
-    assert imageconverter.hexcodes is None
+    try:
+        imageconverter.generate_optimal_cmap(max_colors=5, random_state=42)
+    except UserWarning:
+        pass
+    except Exception:
+        raise Exception("Unexpected exception")

--- a/tests/test_img2cmap.py
+++ b/tests/test_img2cmap.py
@@ -135,11 +135,6 @@ def test_compute_optimal_hexcodes():
 
 
 def test_break_kneed():
-    imageconverter = ImageConverter(image_urls[0])
-    # Case where kneed will not return an optimal value
-    try:
+    with pytest.raises(UserWarning):
+        imageconverter = ImageConverter(image_urls[0])
         imageconverter.generate_optimal_cmap(max_colors=5, random_state=42)
-    except UserWarning:
-        pass
-    except Exception:
-        raise Exception("Unexpected exception")

--- a/tests/test_img2cmap.py
+++ b/tests/test_img2cmap.py
@@ -122,6 +122,20 @@ def test_remove_transparency(test_image_input):
 @pytest.mark.parametrize("test_image_input", images)
 def test_compute_hexcodes(test_image_input):
     imageconverter = ImageConverter(test_image_input)
-    imageconverter.compute_hexcodes()
+    imageconverter.generate_cmap(4, "miami", 42)
+
     assert imageconverter.hexcodes is not None
-    assert len(imageconverter.hexcodes) == len(imageconverter.pixels)
+    assert len(imageconverter.hexcodes) == 4
+
+
+def test_compute_optimal_hexcodes():
+    imageconverter = ImageConverter(image_urls[0])
+    imageconverter.generate_optimal_cmap(max_colors=8, random_state=42)
+    assert imageconverter.hexcodes is not None
+
+
+def test_break_kneed():
+    imageconverter = ImageConverter(image_urls[0])
+    # Case where kneed will not return an optimal value
+    imageconverter.generate_optimal_cmap(max_colors=5, random_state=42)
+    assert imageconverter.hexcodes is None

--- a/tests/test_img2cmap.py
+++ b/tests/test_img2cmap.py
@@ -117,3 +117,11 @@ def test_remove_transparency(test_image_input):
     imageconverter.remove_transparent()
     cmap = imageconverter.generate_cmap(4, "miami", 42)
     assert cmap.N == 4
+
+
+@pytest.mark.parametrize("test_image_input", images)
+def test_compute_hexcodes(test_image_input):
+    imageconverter = ImageConverter(test_image_input)
+    imageconverter.compute_hexcodes()
+    assert imageconverter.hexcodes is not None
+    assert len(imageconverter.hexcodes) == len(imageconverter.pixels)


### PR DESCRIPTION
…I made takes a few seconds to compute)

**Elaborating**
I was looking for vectorized ways of converting RGB values to hex values (and if you find one that works feel free to reject my pull request), but I ended up just doing a pretty simple list comprehension in order to get hex codes. It took 5+ seconds to run on my test image in notebook and I think similar for other images. I thought that would be too slow to compute in the __init__ method so I made an a separate method call that stores the hex codes for an image, much like you do in `resize` and `remove_transparent`

